### PR TITLE
Corregir scroll en Donatello, medida de texto en docs y copy de Gazebo/RViz

### DIFF
--- a/src/components/landing/LandingHero.astro
+++ b/src/components/landing/LandingHero.astro
@@ -60,6 +60,10 @@ import { SITE, withBase } from '../../config/site';
   const story = stage?.closest<HTMLElement>('.landing-donatello-story') ?? null;
   const status = stage?.querySelector<HTMLElement>('.landing-viewer-status') ?? null;
   const controlSurface = story?.querySelector<HTMLElement>('[data-robot-controls]') ?? null;
+  // Las custom properties se escriben en cada frame de scroll. Setearlas en <figure>
+  // y no en .landing-donatello-story limita el recálculo de estilos a los tres hijos
+  // del visor, en vez de invalidar todo el subárbol de la sección (hero + perfil).
+  const viewer = stage?.closest<HTMLElement>('.landing-viewer') ?? null;
 
   const reportError = (message: string) => {
     if (!status) return;
@@ -155,6 +159,7 @@ import { SITE, withBase } from '../../config/site';
       let resumeRotationTimer = 0;
       let stageWidth = 1;
       let stageHeight = 1;
+      let loopRunning = false;
 
       const draw = () => {
         renderer.render(scene, camera);
@@ -252,11 +257,12 @@ import { SITE, withBase } from '../../config/site';
         camera.setViewOffset(stageWidth, stageHeight, -visualShift, 0, stageWidth, stageHeight);
         camera.updateProjectionMatrix();
 
-        story?.style.setProperty('--landing-visual-shift', `${visualShift.toFixed(2)}px`);
-        story?.style.setProperty('--landing-viewer-caption-opacity', captionOpacity.toFixed(3));
-        stage.dataset.storyProgress = storyProgress.toFixed(3);
+        viewer?.style.setProperty('--landing-visual-shift', `${visualShift.toFixed(2)}px`);
+        viewer?.style.setProperty('--landing-viewer-caption-opacity', captionOpacity.toFixed(3));
 
-        if (modelReady && viewerVisible && !document.hidden) draw();
+        // Si el loop de animación ya está corriendo, él dibuja el frame: pintar acá
+        // además duplica el render en cada scroll.
+        if (modelReady && viewerVisible && !document.hidden && !loopRunning) draw();
       };
 
       const updateStoryProgress = () => {
@@ -289,7 +295,10 @@ import { SITE, withBase } from '../../config/site';
 
       const syncRenderLoop = () => {
         const shouldLoop = modelReady && !reducedMotion && viewerVisible && !document.hidden;
-        renderer.setAnimationLoop(shouldLoop ? renderFrame : null);
+        if (shouldLoop !== loopRunning) {
+          loopRunning = shouldLoop;
+          renderer.setAnimationLoop(shouldLoop ? renderFrame : null);
+        }
         if (modelReady && viewerVisible && !shouldLoop && !document.hidden) draw();
       };
 
@@ -371,7 +380,7 @@ import { SITE, withBase } from '../../config/site';
           viewerVisible = entry?.isIntersecting ?? false;
           syncRenderLoop();
         },
-        { threshold: 0.05 }
+        { rootMargin: '15% 0px' }
       );
       visibilityObserver.observe(stage);
       document.addEventListener('visibilitychange', syncRenderLoop);

--- a/src/content/docs/setup/gazebo-rviz.md
+++ b/src/content/docs/setup/gazebo-rviz.md
@@ -62,16 +62,18 @@ Deberías ver una vista 3D vacía y el panel de displays a la izquierda. Por aho
 
 ## Qué deberías ver
 
-Las dos aplicaciones tienen que abrir, responder normalmente y cerrarse sin errores. Cuando levantes el simulador, Gazebo va a mostrar el robot y RViz va a organizar los datos que publica ROS 2.
+Las dos aplicaciones tienen que abrir, responder normalmente y cerrarse sin errores.
+
+Por ahora las dos se ven vacías: Gazebo con un mundo sin nada y RViz con la vista 3D en gris, sin ningún dato. Está bien que sea así, porque todavía no hay un robot ni nadie publicando. Recién cuando levantes el simulador y avances con los workshops las vas a ver como en estas capturas:
 
 <div class="doc-media-pair doc-figure">
   <figure>
     <img src="../../media/donatello-gazebo-poster.webp" alt="Donatello dentro del simulador de Gazebo" width="960" height="520" loading="lazy" />
-    <figcaption>Gazebo representa el entorno, el movimiento y los contactos del robot.</figcaption>
+    <figcaption>Más adelante: Gazebo con Donatello en el mundo del desafío, simulando movimiento y contactos.</figcaption>
   </figure>
   <figure>
     <img src="../../media/donatello-rviz-poster.webp" alt="Datos de Donatello visualizados en RViz" width="960" height="520" loading="lazy" />
-    <figcaption>RViz muestra la información que circula por ROS 2, como LiDAR, cámara y odometría.</figcaption>
+    <figcaption>Más adelante: RViz mostrando lo que publica el robot, como el LiDAR, la cámara y la odometría.</figcaption>
   </figure>
 </div>
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -949,7 +949,7 @@ footer.site-footer {
 .docs-body .prose > ul,
 .docs-body .prose > ol,
 .docs-body .prose > blockquote:not(.doc-callout) {
-  max-width: 65ch;
+  max-width: 90ch;
 }
 
 .docs-body .prose h2 {

--- a/src/styles/landing.css
+++ b/src/styles/landing.css
@@ -264,7 +264,7 @@
 
 .landing-viewer-status {
   position: absolute;
-  inset: 50% auto auto calc(50% + var(--landing-visual-shift));
+  inset: 50% auto auto 50%;
   z-index: 4;
   width: min(90%, 28rem);
   color: var(--text-3);
@@ -272,7 +272,7 @@
   line-height: 1.6;
   letter-spacing: 0.06em;
   text-align: center;
-  transform: translate(-50%, -50%);
+  transform: translate(calc(-50% + var(--landing-visual-shift)), -50%);
   transition: opacity 0.25s var(--ease);
 }
 
@@ -287,7 +287,7 @@
 .landing-viewer-caption {
   position: absolute;
   z-index: 4;
-  left: calc(50% + var(--landing-visual-shift));
+  left: 50%;
   bottom: -3rem;
   min-height: 44px;
   width: min(calc(100% - (var(--landing-gutter) * 2)), 34rem);
@@ -299,8 +299,7 @@
   line-height: 1.5;
   text-align: center;
   opacity: var(--landing-viewer-caption-opacity);
-  transform: translateX(-50%);
-  transition: opacity 0.2s var(--ease);
+  transform: translateX(calc(-50% + var(--landing-visual-shift)));
 }
 
 .landing-viewer-caption-touch {


### PR DESCRIPTION
## Summary

- Corrige el scroll trabado en la sección de Donatello: las variables CSS que actualiza el scroll dejan de alimentar `left`/`inset` y pasan a `transform`, se setean sobre `.landing-viewer` en vez del subárbol entero de la sección, se elimina el doble render por frame (el animation loop y el handler de scroll llamaban a `draw()` por separado) y el `IntersectionObserver` pasa de `threshold: 0.05` a `rootMargin: 15%` para que el render loop no oscile justo en el borde de salida
- Sube la medida de párrafos, listas y citas en docs de `65ch` a `90ch`: quedaban cortos frente a los bloques de código y las figuras, que no tienen ese tope
- Reescribe "Qué deberías ver" de Gazebo y RViz: a esa altura del setup las últimas instrucciones son abrir un mundo vacío y `rviz2` a secas, así que las capturas con el robot y con datos no correspondían a ese paso; ahora se aclara que las dos se ven vacías y las imágenes quedan etiquetadas como referencia de lo que se ve más adelante

## Test plan

- [X] `npm run check` sin errores
- [X] `npm run build` sin errores (11 páginas)
- [X] Verificar el scroll de la sección de Donatello entrando y saliendo del visor
- [X] Confirmar el nuevo ancho de párrafos en `/setup/gazebo-rviz/`
- [ ] Queda un resto de jank leve en el scroll, muy por debajo de lo reportado originalmente