### PR TITLE
Agregar sitemap para buscadores

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -31,7 +31,8 @@ Backlog compartido para quienes sigan trabajando en el sitio. Antes de arrancar:
 - [x] **Optimizar meshes 3D e integrar modelo CAD unificado** — integró el modelo CAD unificado de alta fidelidad en `public/models/rosmaster_unified.glb` (7.8 MB, bajando de ~32 MB de mallas URDF dispersas), con ajuste de la cámara RGB-D (-1 cm Z) para resolver la interferencia con el bulón de fijación.
 - [ ] **Revisar la estructura superior del URDF** — en el visor sobresale un mástil con caños sobre el chasis. Confirmar que es parte real del xacro y no algo que convenga ocultar para la web (el loader permite ocultar links puntuales).
 - [ ] **Página 404** — crear `src/pages/404.astro` amigable; GitHub Pages la sirve automáticamente si está en el build.
-- [x] **Sitemap para buscadores** — integración `@astrojs/sitemap` y enlace de descubrimiento en el `<head>` compartido.
+- [x] **Sitemap para buscadores** — integración `@astrojs/sitemap` con las 11 rutas públicas y sin duplicar la landing.
+- [ ] **robots.txt en la raíz de GitHub Pages** — requiere crear el sitio de organización `AIRclub-UdeSA/airclub-udesa.github.io`; seguimiento en [`AIRclub-UdeSA/.github#1`](https://github.com/AIRclub-UdeSA/.github/issues/1).
 - [x] **Warning de THREE.Clock y optimización del visor** — reemplazo de APIs obsoletas, zoom condicional (`isMouseDown`), centrado y escalado automático optimizado.
 
 ## Comunidad e inscripción

--- a/TODO.md
+++ b/TODO.md
@@ -32,7 +32,7 @@ Backlog compartido para quienes sigan trabajando en el sitio. Antes de arrancar:
 - [ ] **Revisar la estructura superior del URDF** — en el visor sobresale un mástil con caños sobre el chasis. Confirmar que es parte real del xacro y no algo que convenga ocultar para la web (el loader permite ocultar links puntuales).
 - [ ] **Página 404** — crear `src/pages/404.astro` amigable; GitHub Pages la sirve automáticamente si está en el build.
 - [x] **Sitemap para buscadores** — integración `@astrojs/sitemap` con las 11 rutas públicas y sin duplicar la landing.
-- [ ] **robots.txt en la raíz de GitHub Pages** — requiere crear el sitio de organización `AIRclub-UdeSA/airclub-udesa.github.io`; seguimiento en [`AIRclub-UdeSA/.github#1`](https://github.com/AIRclub-UdeSA/.github/issues/1).
+- [ ] **robots.txt en la raíz de GitHub Pages** — el sitio de organización `AIRclub-UdeSA/airclub-udesa.github.io` ya está publicado y su `robots.txt` responde 200 con la línea `Sitemap:`; queda verificar que el sitemap responda 200 al integrar este PR. Seguimiento en [`AIRclub-UdeSA/.github#1`](https://github.com/AIRclub-UdeSA/.github/issues/1).
 - [x] **Warning de THREE.Clock y optimización del visor** — reemplazo de APIs obsoletas, zoom condicional (`isMouseDown`), centrado y escalado automático optimizado.
 
 ## Comunidad e inscripción

--- a/TODO.md
+++ b/TODO.md
@@ -31,7 +31,7 @@ Backlog compartido para quienes sigan trabajando en el sitio. Antes de arrancar:
 - [x] **Optimizar meshes 3D e integrar modelo CAD unificado** — integró el modelo CAD unificado de alta fidelidad en `public/models/rosmaster_unified.glb` (7.8 MB, bajando de ~32 MB de mallas URDF dispersas), con ajuste de la cámara RGB-D (-1 cm Z) para resolver la interferencia con el bulón de fijación.
 - [ ] **Revisar la estructura superior del URDF** — en el visor sobresale un mástil con caños sobre el chasis. Confirmar que es parte real del xacro y no algo que convenga ocultar para la web (el loader permite ocultar links puntuales).
 - [ ] **Página 404** — crear `src/pages/404.astro` amigable; GitHub Pages la sirve automáticamente si está en el build.
-- [ ] **sitemap + robots.txt** — integración `@astrojs/sitemap` y `robots.txt` en `public/`.
+- [x] **Sitemap para buscadores** — integración `@astrojs/sitemap` y enlace de descubrimiento en el `<head>` compartido.
 - [x] **Warning de THREE.Clock y optimización del visor** — reemplazo de APIs obsoletas, zoom condicional (`isMouseDown`), centrado y escalado automático optimizado.
 
 ## Comunidad e inscripción

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,11 +1,17 @@
 // @ts-check
 import { defineConfig } from 'astro/config';
+import sitemap from '@astrojs/sitemap';
 import { satteri } from '@astrojs/markdown-satteri';
 import callouts from './src/markdown/callouts.mjs';
 
+const site = 'https://airclub-udesa.github.io';
+const base = '/jar_site';
+const rootWithoutTrailingSlash = new URL(base, site).href;
+
 export default defineConfig({
-  site: 'https://airclub-udesa.github.io',
-  base: '/jar_site',
+  site,
+  base,
+  integrations: [sitemap({ filter: (page) => page !== rootWithoutTrailingSlash })],
   markdown: {
     processor: satteri({ mdastPlugins: [callouts] }),
     shikiConfig: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "jar-site",
       "version": "0.1.0",
       "dependencies": {
+        "@astrojs/sitemap": "^3.7.3",
         "astro": "^7.2.4",
         "three": "^0.185.1",
         "urdf-loader": "^0.13.1"
@@ -312,6 +313,17 @@
       },
       "engines": {
         "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/sitemap": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.7.3.tgz",
+      "integrity": "sha512-f8euLVsyeAmAkSm/1M2Kb8sL8byQmfgbvBNaHFItCheTj/IpiJYSEWVcqDHZ/yEHxiS7+w87mQkzwZaPHmk5GA==",
+      "license": "MIT",
+      "dependencies": {
+        "sitemap": "^9.0.0",
+        "stream-replace-string": "^2.0.0",
+        "zod": "^4.3.6"
       }
     },
     "node_modules/@astrojs/telemetry": {
@@ -2122,6 +2134,24 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/sax": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.7.tgz",
+      "integrity": "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/stats.js": {
       "version": "0.17.4",
       "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
@@ -2374,6 +2404,12 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -4283,6 +4319,25 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
     },
+    "node_modules/sitemap": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-9.0.1.tgz",
+      "integrity": "sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^24.9.2",
+        "@types/sax": "^1.2.1",
+        "arg": "^5.0.0",
+        "sax": "^1.4.1"
+      },
+      "bin": {
+        "sitemap": "dist/esm/cli.js"
+      },
+      "engines": {
+        "node": ">=20.19.5",
+        "npm": ">=10.8.2"
+      }
+    },
     "node_modules/smol-toml": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.8.0.tgz",
@@ -4313,6 +4368,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/stream-replace-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stream-replace-string/-/stream-replace-string-2.0.0.tgz",
+      "integrity": "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==",
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "8.2.2",
@@ -4537,6 +4598,12 @@
       "engines": {
         "node": ">=22.19.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "license": "MIT"
     },
     "node_modules/unified": {
       "version": "11.0.5",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "check": "astro check"
   },
   "dependencies": {
+    "@astrojs/sitemap": "^3.7.3",
     "astro": "^7.2.4",
     "three": "^0.185.1",
     "urdf-loader": "^0.13.1"

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -21,7 +21,6 @@ const fullTitle = title ? `${title} · ${SITE.name}` : `${SITE.name} · ${SITE.t
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>{fullTitle}</title>
     <meta name="description" content={description} />
-    <link rel="sitemap" href={withBase('/sitemap-index.xml')} />
     <link rel="icon" type="image/svg+xml" href={withBase('/favicon.svg')} />
     <link rel="icon" type="image/png" sizes="32x32" href={withBase('/favicon-32x32.png')} />
     <link rel="shortcut icon" href={withBase('/favicon.ico')} />

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -21,6 +21,7 @@ const fullTitle = title ? `${title} · ${SITE.name}` : `${SITE.name} · ${SITE.t
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>{fullTitle}</title>
     <meta name="description" content={description} />
+    <link rel="sitemap" href={withBase('/sitemap-index.xml')} />
     <link rel="icon" type="image/svg+xml" href={withBase('/favicon.svg')} />
     <link rel="icon" type="image/png" sizes="32x32" href={withBase('/favicon-32x32.png')} />
     <link rel="shortcut icon" href={withBase('/favicon.ico')} />


### PR DESCRIPTION
## Resumen

- integra `@astrojs/sitemap` conservando `site` y `base`
- genera `/jar_site/sitemap-index.xml` con las 11 rutas públicas
- evita duplicar la landing con y sin slash final
- separa el seguimiento pendiente de `robots.txt` y lo vincula con AIRclub-UdeSA/.github#1
- actualiza el backlog técnico sin presentar `<link rel="sitemap">` como mecanismo de descubrimiento

## Verificación

- `npm run check`
- `npm run build`
- sitemap generado con las 11 rutas públicas, sin duplicar la landing

Closes #13