### PR TITLE
Agregar página 404 con ilustración del robot fuera del mapa

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -30,7 +30,7 @@ Backlog compartido para quienes sigan trabajando en el sitio. Antes de arrancar:
 
 - [x] **Optimizar meshes 3D e integrar modelo CAD unificado** — integró el modelo CAD unificado de alta fidelidad en `public/models/rosmaster_unified.glb` (7.8 MB, bajando de ~32 MB de mallas URDF dispersas), con ajuste de la cámara RGB-D (-1 cm Z) para resolver la interferencia con el bulón de fijación.
 - [ ] **Revisar la estructura superior del URDF** — en el visor sobresale un mástil con caños sobre el chasis. Confirmar que es parte real del xacro y no algo que convenga ocultar para la web (el loader permite ocultar links puntuales).
-- [ ] **Página 404** — crear `src/pages/404.astro` amigable; GitHub Pages la sirve automáticamente si está en el build.
+- [x] **Página 404** — `src/pages/404.astro` con ilustración del robot fuera del mapa (`public/media/404/robot-perdido.svg`) y accesos a inicio, setup y workshops; GitHub Pages la sirve automáticamente desde el build.
 - [ ] **sitemap + robots.txt** — integración `@astrojs/sitemap` y `robots.txt` en `public/`.
 - [x] **Warning de THREE.Clock y optimización del visor** — reemplazo de APIs obsoletas, zoom condicional (`isMouseDown`), centrado y escalado automático optimizado.
 

--- a/TODO.md
+++ b/TODO.md
@@ -30,7 +30,7 @@ Backlog compartido para quienes sigan trabajando en el sitio. Antes de arrancar:
 
 - [x] **Optimizar meshes 3D e integrar modelo CAD unificado** — integró el modelo CAD unificado de alta fidelidad en `public/models/rosmaster_unified.glb` (7.8 MB, bajando de ~32 MB de mallas URDF dispersas), con ajuste de la cámara RGB-D (-1 cm Z) para resolver la interferencia con el bulón de fijación.
 - [ ] **Revisar la estructura superior del URDF** — en el visor sobresale un mástil con caños sobre el chasis. Confirmar que es parte real del xacro y no algo que convenga ocultar para la web (el loader permite ocultar links puntuales).
-- [ ] **Página 404** — crear `src/pages/404.astro` amigable; GitHub Pages la sirve automáticamente si está en el build.
+- [x] **Página 404** — `src/pages/404.astro` con ilustración del robot fuera del mapa (`public/media/404/robot-perdido.svg`) y accesos a inicio, setup y workshops; GitHub Pages la sirve automáticamente desde el build.
 - [x] **Sitemap para buscadores** — integración `@astrojs/sitemap` con las 11 rutas públicas y sin duplicar la landing.
 - [ ] **robots.txt en la raíz de GitHub Pages** — el sitio de organización `AIRclub-UdeSA/airclub-udesa.github.io` ya está publicado y su `robots.txt` responde 200 con la línea `Sitemap:`; queda verificar que el sitemap responda 200 al integrar este PR. Seguimiento en [`AIRclub-UdeSA/.github#1`](https://github.com/AIRclub-UdeSA/.github/issues/1).
 - [x] **Warning de THREE.Clock y optimización del visor** — reemplazo de APIs obsoletas, zoom condicional (`isMouseDown`), centrado y escalado automático optimizado.

--- a/public/media/404/robot-perdido.svg
+++ b/public/media/404/robot-perdido.svg
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="50 25 510 290" role="img" aria-label="El recorrido de un robot atraviesa el mapa conocido, sale por el borde y el robot queda afuera, confundido">
+
+  <rect x="265" y="45" width="250" height="250" rx="4" fill="#f2f6f1" fill-opacity=".05"/>
+
+  <g fill="#f2f6f1" fill-opacity=".14" stroke="#f2f6f1" stroke-opacity=".34" stroke-width="1.5">
+    <rect x="445" y="95" width="45" height="40" rx="3"/>
+    <rect x="300" y="225" width="60" height="45" rx="3"/>
+    <rect x="360" y="55" width="40" height="35" rx="3"/>
+  </g>
+
+  <g fill="#f2f6f1" fill-opacity=".3">
+    <rect x="416" y="45" width="8" height="105" rx="2"/>
+    <rect x="416" y="210" width="8" height="85" rx="2"/>
+    <rect x="310" y="186" width="106" height="8" rx="2"/>
+    <rect x="265" y="106" width="95" height="8" rx="2"/>
+  </g>
+
+  <rect x="265" y="45" width="250" height="250" rx="4" fill="none" stroke="#f2f6f1" stroke-opacity=".4" stroke-width="2"/>
+
+  <path d="M475 265 L465 180 L390 168 L385 125 L290 130 L265 133 L215 152 L175 170 L150 181" fill="none" stroke="#4ade80" stroke-width="2.5" stroke-linecap="round" stroke-dasharray="2 8"/>
+
+  <g transform="translate(131.2 189.7) rotate(245.8) scale(0.75)">
+    <rect x="-32" y="-24" width="64" height="48" rx="9" fill="#0b120f" stroke="#4ade80" stroke-width="2"/>
+    <rect x="-38" y="-18" width="9" height="14" rx="3" fill="#15221a" stroke="#4ade80" stroke-width="1.5"/>
+    <rect x="29" y="-18" width="9" height="14" rx="3" fill="#15221a" stroke="#4ade80" stroke-width="1.5"/>
+    <rect x="-38" y="5" width="9" height="14" rx="3" fill="#15221a" stroke="#4ade80" stroke-width="1.5"/>
+    <rect x="29" y="5" width="9" height="14" rx="3" fill="#15221a" stroke="#4ade80" stroke-width="1.5"/>
+    <circle cx="0" cy="0" r="8" fill="none" stroke="#f2f6f1" stroke-opacity=".5" stroke-width="2"/>
+    <circle cx="0" cy="-18" r="2.5" fill="#4ade80"/>
+  </g>
+
+  <g fill="#fbbf24" font-family="'JetBrains Mono', 'Courier New', monospace" font-weight="600" text-anchor="middle">
+    <text x="103" y="164" font-size="26" opacity="1">?</text>
+    <text x="86" y="175" font-size="19" opacity=".85">?</text>
+    <text x="112" y="143" font-size="14" opacity=".7">?</text>
+  </g>
+</svg>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,0 +1,79 @@
+---
+import '../styles/landing.css';
+import Base from '../layouts/Base.astro';
+import { withBase } from '../config/site';
+---
+
+<Base title="Página no encontrada" bodyClass="landing-body">
+  <main id="main-content" class="landing-page">
+    <section class="landing-section" aria-labelledby="notfound-title">
+      <div class="landing-shell notfound-layout">
+        <div class="notfound-copy">
+          <header class="landing-section-heading">
+            <p class="landing-eyebrow">Error 404</p>
+            <h1 id="notfound-title">Esta página no existe.</h1>
+            <p>
+              Puede que la dirección esté mal escrita o que el contenido haya cambiado de lugar.
+              Desde acá volvés al recorrido principal del Challenge JAR.
+            </p>
+          </header>
+
+          <nav class="landing-actions" aria-label="Salidas desde el error">
+            <a class="landing-action landing-action-primary" href={withBase('/')}>
+              Ir al inicio
+              <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 12h14M12 5l7 7-7 7"></path></svg>
+            </a>
+            <a class="landing-action landing-action-secondary" href={withBase('/setup/')}>
+              Preparar el entorno
+            </a>
+            <a class="landing-action landing-action-secondary" href={withBase('/workshops/')}>
+              Ver los workshops
+            </a>
+          </nav>
+        </div>
+
+        <figure class="notfound-figure">
+          <img
+            src={withBase('/media/404/robot-perdido.svg')}
+            alt="El recorrido de Donatello sale del mapa conocido y el robot queda afuera, confundido"
+            width="510"
+            height="290"
+            loading="lazy"
+          />
+        </figure>
+      </div>
+    </section>
+  </main>
+</Base>
+
+<style>
+  .notfound-layout {
+    display: grid;
+    gap: clamp(2.5rem, 6vw, 4.5rem);
+    align-items: center;
+  }
+
+  .notfound-copy .landing-section-heading {
+    margin-bottom: clamp(2rem, 4vw, 2.75rem);
+  }
+
+  .notfound-figure {
+    margin: 0;
+  }
+
+  .notfound-figure img {
+    width: 100%;
+    height: auto;
+    display: block;
+  }
+
+  @media (min-width: 56rem) {
+    .notfound-layout {
+      grid-template-columns: minmax(0, 1fr) minmax(0, 0.95fr);
+    }
+
+    .notfound-figure {
+      order: 2;
+    }
+  }
+</style>

--- a/src/styles/landing.css
+++ b/src/styles/landing.css
@@ -63,6 +63,7 @@
   margin-bottom: clamp(3rem, 7vw, 5.5rem);
 }
 
+.landing-section-heading h1,
 .landing-section-heading h2,
 .landing-event-heading h2,
 .landing-application h2,
@@ -72,6 +73,7 @@
   letter-spacing: -0.04em;
 }
 
+.landing-section-heading h1,
 .landing-section-heading h2 {
   max-width: 12ch;
   color: var(--landing-ink);


### PR DESCRIPTION
## Summary

- Agrega `src/pages/404.astro`, que Astro compila a `dist/404.html` y GitHub Pages sirve automáticamente para cualquier ruta inexistente bajo `/jar_site`. Hasta ahora esas URLs devolvían la página genérica de GitHub, en inglés y sin ninguna forma de volver al sitio
- Reutiliza el shell y las clases existentes: `Base` aporta nav, footer, fuentes y favicons, y la composición usa `landing-section-heading`, `landing-actions` y `landing-action`. Todos los enlaces pasan por `withBase()`
- Ofrece tres salidas —inicio, setup y workshops— en una grilla de dos columnas desde `56rem`, con la ilustración al lado del texto; en mobile queda apilada
- Suma `public/media/404/robot-perdido.svg` (2 KB): un plano con paredes internas y obstáculos, el recorrido punteado que lo atraviesa y sale por el borde, y el robot afuera con signos de pregunta. Estático y sin rótulos, así que no necesita variante `prefers-reduced-motion` ni versión mobile
- Extiende los selectores de `landing-section-heading` para cubrir `h1`. El encabezado principal de una página tiene que ser `h1` por semántica y accesibilidad, y hasta ahora solo estaba contemplado `h2`
- Marca el ítem **Página 404** del `TODO.md` como completado, que es lo que este PR resuelve

## Criterios de aceptación del #11

- [X] La página usa el shell y los tokens existentes
- [X] No introduce una estética o navegación paralela — sin clases nuevas; solo se extendió un selector ya existente
- [X] Se genera como `dist/404.html`
- [X] Los enlaces respetan el base path `/jar_site`
- [X] `npm run check && npm run build` pasa sin errores

## Test plan

- [X] `npm run check` sin errores
- [X] `npm run build` sin errores (12 páginas, `/404.html` incluida)
- [X] Verificado que los 9 `href` del HTML generado llevan el prefijo `/jar_site`, ninguno sin él
- [X] Verificado que ninguna otra página tiene un `h1` dentro de los contenedores cuyo selector se extendió, así que el cambio de CSS no altera nada existente
- [X] El recorrido punteado no cruza ninguna de las 7 formas del plano (chequeo por muestreo de 300 puntos por segmento)
- [X] El SVG no contiene elementos `<animate>` y sus únicos `<text>` son los tres signos de pregunta
- [x] **Revisión visual de la ilustración — pendiente de quien revise**

## Nota para quien revise

El punto que falta del test plan es deliberado y **no se puede cerrar leyendo el diff**: la ilustración es un SVG dibujado por coordenadas, así que si la revisión se hace con una herramienta que no renderiza la página, no hay forma de saber si funciona.

Concretamente, mirá `/jar_site/404` (o cualquier ruta inventada) y opiná sobre:

- Si el plano se lee como un mapa con ambientes y no como bloques sueltos
- Si el robot tiene un tamaño creíble para haber recorrido esos pasillos
- Si su orientación acompaña el final del trayecto
- Si los signos de pregunta transmiten la confusión sin recargar
- Si en pantalla ancha la ilustración y el texto quedan bien balanceados, y si al bajar de `56rem` apila correctamente

Todo lo demás del test plan está verificado de forma objetiva; esto es lo único que depende de un ojo humano.

Closes #11