### PR TITLE
Aclarar sede: Predio del CUR · La Siberia

### DIFF
--- a/src/components/landing/EventDetails.astro
+++ b/src/components/landing/EventDetails.astro
@@ -30,7 +30,7 @@ import { SITE } from '../../config/site';
           <span aria-hidden="true">↗</span>
         </a>
         <a href={SITE.event.venueUrl} target="_blank" rel="noopener">
-          <span>Sede FCEIA · UNR</span>
+          <span>Ubicación: CUR · "La Siberia"</span>
           <span aria-hidden="true">↗</span>
         </a>
       </nav>

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -14,9 +14,9 @@ export const SITE = {
     city: 'Rosario',
     dateRange: '3 al 6 de noviembre de 2026',
     shortDate: '03–06 nov 2026',
-    venue: 'FCEIA · UNR',
+    venue: 'Predio del CUR · "La Siberia"',
     officialUrl: 'https://jar.net.ar/',
-    venueUrl: 'https://web.fceia.unr.edu.ar/',
+    venueUrl: 'https://www.google.com/maps/place/La+Siberia+-+Centro+Universitario+Rosario+(CUR)/@-32.9666336,-60.6257725,15.63z/data=!4m6!3m5!1s0x95b7aa53ea64d915:0x3538499b08835639!8m2!3d-32.9661559!4d-60.6233572!16s%2Fg%2F1224z7kt',
   },
 };
 


### PR DESCRIPTION
## Resumen
- Un organizador de la JAR avisó que poner solo "FCEIA · UNR" genera confusión: se puede interpretar como el edificio de Pellegrini (a ~1km), cuando el evento es en el Predio del CUR ("La Siberia").
- Se actualiza `SITE.event.venue` y `SITE.event.venueUrl` para reflejar la sede correcta, con link directo a Google Maps.
- Se actualiza el texto del link de ubicación en la sección de detalles del evento (home).

## Test plan
- [x] `npm run build` sin errores
- [x] Verificado visualmente en `npm run dev` (sección "JAR 2026" del home)