### PR TITLE
feat: agregar botón flotante de feedback

### DIFF
--- a/src/components/FeedbackButton.astro
+++ b/src/components/FeedbackButton.astro
@@ -1,0 +1,77 @@
+---
+import { FEEDBACK_FORM } from '../config/site';
+
+const page = Astro.url.pathname;
+const feedbackUrl = `${FEEDBACK_FORM.baseUrl}?usp=pp_url&${FEEDBACK_FORM.pageFieldEntry}=${encodeURIComponent(page)}`;
+---
+
+<a
+  class="feedback-button"
+  href={feedbackUrl}
+  target="_blank"
+  rel="noopener"
+  aria-label="Dejar feedback sobre esta página"
+>
+  <svg viewBox="0 0 24 24" aria-hidden="true">
+    <path
+      d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z"
+    ></path>
+  </svg>
+  <span>Feedback</span>
+</a>
+
+<style>
+  .feedback-button {
+    position: fixed;
+    right: 1.25rem;
+    bottom: calc(1.25rem + env(safe-area-inset-bottom, 0px));
+    z-index: 900;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    min-height: 44px;
+    padding: 0 1rem;
+    background: var(--accent);
+    color: #04140a;
+    font-family: var(--font-body);
+    font-size: 0.82rem;
+    font-weight: 700;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+    transition:
+      background-color 0.2s var(--ease),
+      transform 0.2s var(--ease);
+  }
+
+  .feedback-button:hover {
+    background: var(--accent-bright);
+    transform: translateY(-2px);
+  }
+
+  .feedback-button svg {
+    width: 1.05rem;
+    height: 1.05rem;
+    flex-shrink: 0;
+    fill: none;
+    stroke: currentColor;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    stroke-width: 1.8;
+  }
+
+  @media (max-width: 30rem) {
+    .feedback-button {
+      width: 44px;
+      padding: 0;
+      justify-content: center;
+    }
+
+    .feedback-button span {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+    }
+  }
+</style>

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -20,6 +20,12 @@ export const SITE = {
   },
 };
 
+export const FEEDBACK_FORM = {
+  baseUrl:
+    'https://docs.google.com/forms/d/e/1FAIpQLSeJ8gf2zANiKyIARlJ1w-5W6X2qYvt6t2c25PlYqyXTiDly7g/viewform',
+  pageFieldEntry: 'entry.1385103228',
+};
+
 export const withBase = (path: string): string => {
   const base = import.meta.env.BASE_URL.replace(/\/+$/, '');
   return `${base}${path}`;

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -2,6 +2,7 @@
 import '../styles/global.css';
 import Nav from '../components/Nav.astro';
 import Footer from '../components/Footer.astro';
+import FeedbackButton from '../components/FeedbackButton.astro';
 import { SITE, withBase } from '../config/site';
 
 interface Props {
@@ -41,5 +42,6 @@ const fullTitle = title ? `${title} · ${SITE.name}` : `${SITE.name} · ${SITE.t
     <Nav />
     <slot />
     <Footer />
+    <FeedbackButton />
   </body>
 </html>


### PR DESCRIPTION
## Resumen

- Botón flotante fijo abajo a la derecha, montado en `Base.astro`, presente en todas las páginas (landing, docs, workshops, setup, 404).
- Al hacer click abre el Google Form de feedback (#18) en una pestaña nueva, con la página actual precargada vía el mecanismo de prefill de Google Forms.
- URL base del form y `entry.<id>` del campo "página" viven en `src/config/site.ts` (`FEEDBACK_FORM`), no hardcodeados en el componente.
- Reusa los tokens de `src/styles/global.css` (`--accent`, `--accent-bright`, fuentes, `--ease`) para mantener la estética del sitio.
- En mobile colapsa a un botón circular de 44px solo con ícono; el label "Feedback" queda accesible para lectores de pantalla.
- `aria-label="Dejar feedback sobre esta página"`, navegable por teclado (es un `<a>` estándar).

Closes #17.

## Test plan

- [x] `npm run check` sin errores
- [x] `npm run build` sin errores
- [x] Probado en dev server: aparece en home, `/setup/`, `/workshops/`, páginas de workshop y 404
- [x] Verificado que el link abierto precarga correctamente la ruta actual en el campo "página" del form
- [x] Probado en viewport mobile: no tapa el footer, colapsa a ícono
- [x] Navegación por teclado (Tab + Enter) funciona