### PR TITLE
fix: sidebar sólo muestra la sección activa

### DIFF
--- a/src/components/Sidebar.astro
+++ b/src/components/Sidebar.astro
@@ -16,6 +16,11 @@ const isActive = (href: string): boolean => {
   return path === target;
 };
 
+// Sólo mostramos la sección a la que pertenece la página actual: evita que
+// Setup aparezca dentro de Workshops (y viceversa) en la barra lateral.
+const setupBase = withBase('/setup/').replace(/\/+$/, '');
+const isSetupSection = path === setupBase || path.startsWith(`${setupBase}/`);
+
 const workshopTitle = (title: string) => {
   const match = title.match(/^(\d{2}) · (.+)$/);
   return match ? { number: match[1], label: match[2] } : { number: '—', label: title };
@@ -23,51 +28,56 @@ const workshopTitle = (title: string) => {
 ---
 
 {
-  DOC_SECTIONS.map((section) => (
-    <div class="side-group">
-      <p class="side-label">{section.label}</p>
-      {section.items.map((item, index) => (
-        <a
-          class:list={['side-link', { active: isActive(item.href) }]}
-          href={withBase(item.href)}
-          aria-current={isActive(item.href) ? 'page' : undefined}
-        >
-          <span class="side-index">{String(index + 1).padStart(2, '0')}</span>
-          <span class="side-link-label">{item.label}</span>
-        </a>
-      ))}
-    </div>
-  ))
+  isSetupSection &&
+    DOC_SECTIONS.map((section) => (
+      <div class="side-group">
+        <p class="side-label">{section.label}</p>
+        {section.items.map((item, index) => (
+          <a
+            class:list={['side-link', { active: isActive(item.href) }]}
+            href={withBase(item.href)}
+            aria-current={isActive(item.href) ? 'page' : undefined}
+          >
+            <span class="side-index">{String(index + 1).padStart(2, '0')}</span>
+            <span class="side-link-label">{item.label}</span>
+          </a>
+        ))}
+      </div>
+    ))
 }
-<div class="side-group">
-  <p class="side-label">Workshops</p>
-  <a
-    class:list={['side-link', { active: isActive('/workshops/') }]}
-    href={withBase('/workshops/')}
-    aria-current={isActive('/workshops/') ? 'page' : undefined}
-  >
-    <span class="side-index">00</span>
-    <span class="side-link-label">Sobre los workshops</span>
-  </a>
-  {
-    weeks.map((week) => {
-      const title = workshopTitle(week.data.title);
-      const active = isActive(`/${week.id}/`);
-      return (
-        <a
-          class:list={['side-link', { active }]}
-          href={withBase(`/${week.id}/`)}
-          aria-current={active ? 'page' : undefined}
-        >
-          <span class="side-index">{title.number}</span>
-          <span class="side-link-label">{title.label}</span>
-          {
-            week.data.status === 'proximamente' && (
-              <span class="soon-dot" role="img" aria-label="Próximamente" />
-            )
-          }
-        </a>
-      );
-    })
-  }
-</div>
+{
+  !isSetupSection && (
+    <div class="side-group">
+      <p class="side-label">Workshops</p>
+      <a
+        class:list={['side-link', { active: isActive('/workshops/') }]}
+        href={withBase('/workshops/')}
+        aria-current={isActive('/workshops/') ? 'page' : undefined}
+      >
+        <span class="side-index">00</span>
+        <span class="side-link-label">Sobre los workshops</span>
+      </a>
+      {
+        weeks.map((week) => {
+          const title = workshopTitle(week.data.title);
+          const active = isActive(`/${week.id}/`);
+          return (
+            <a
+              class:list={['side-link', { active }]}
+              href={withBase(`/${week.id}/`)}
+              aria-current={active ? 'page' : undefined}
+            >
+              <span class="side-index">{title.number}</span>
+              <span class="side-link-label">{title.label}</span>
+              {
+                week.data.status === 'proximamente' && (
+                  <span class="soon-dot" role="img" aria-label="Próximamente" />
+                )
+              }
+            </a>
+          );
+        })
+      }
+    </div>
+  )
+}


### PR DESCRIPTION
## Qué cambia

La barra lateral de la documentación (`Sidebar.astro`) mostraba siempre los dos grupos de enlaces —**Setup** y **Workshops**— sin importar en qué sección estuviera el usuario. Entrando a `/setup/*` se veía también el listado de workshops debajo, y entrando a `/workshops/*` se veía el listado de Setup arriba.

## Por qué pasaba

El componente renderizaba ambos bloques (`DOC_SECTIONS.map(...)` para Setup, y el bloque fijo de Workshops) de forma incondicional, uno después del otro, sin ningún chequeo de en qué sección estaba parada la página actual.

## Cómo se arregló

Se agregó en `Sidebar.astro` un chequeo del `pathname` actual (ya normalizado igual que el resto del sidebar, respetando el `BASE_URL` del sitio) para determinar si la página pertenece a Setup o a Workshops, y ahora sólo se renderiza el grupo correspondiente a esa sección.

- Página en `/setup/...` → sidebar muestra sólo el grupo **Setup**.
- Página en `/workshops/...` → sidebar muestra sólo el grupo **Workshops**.

No cambia ningún otro comportamiento (activos, orden, íconos de "próximamente", etc.).

## Test plan

- [x] `npm run dev` local, verificado con `curl` que `/setup/` renderiza sólo `side-label` "Setup" y `/workshops/` sólo "Workshops".
- [x] Revisión visual en el navegador (recomendado antes de mergear).