### PR TITLE
Migrar de PAT a GitHub App para la auth de Projects

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -11,7 +11,15 @@ jobs:
     name: Add issue/PR to project
     runs-on: ubuntu-latest
     steps:
+      - name: Generar token de la GitHub App
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: AIRclub-UdeSA
+
       - uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/AIRclub-UdeSA/projects/3
-          github-token: ${{ secrets.ORG_PROJECT_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/pr-review-status.yml
+++ b/.github/workflows/pr-review-status.yml
@@ -8,10 +8,18 @@ jobs:
   set-in-review:
     runs-on: ubuntu-latest
     steps:
+      - name: Generar token de la GitHub App
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: AIRclub-UdeSA
+
       - name: Sync project Status with review state
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.ORG_PROJECT_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const projectId = "PVT_kwDOEjyD084BhtOr";
             const statusFieldId = "PVTSSF_lADOEjyD084BhtOrzhgn_fY";


### PR DESCRIPTION
## Resumen
Etapa B del plan de automatización: reemplaza el PAT fine-grained (Etapa A) por la GitHub App `airclub-projects-bot` como mecanismo de auth para escribir en el project.

- Ambos workflows generan un token de instalación al vuelo con `actions/create-github-app-token`, usando los secrets `APP_ID` y `APP_PRIVATE_KEY`.
- No depende de la cuenta de ninguna persona del club y no vence como el PAT.

## Test plan
- [x] Ya validado en jar_workshops
- [ ] Mergear