### PR TITLE
Sincronizar Status con assignees y propagar el review al issue vinculado

### DIFF
--- a/.github/workflows/assignee-status.yml
+++ b/.github/workflows/assignee-status.yml
@@ -1,0 +1,118 @@
+name: Sync assignee status
+
+on:
+  issues:
+    types: [assigned, unassigned]
+  pull_request:
+    types: [assigned, unassigned]
+
+jobs:
+  set-in-progress:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generar token de la GitHub App
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: AIRclub-UdeSA
+
+      - name: Sync project Status with assignees
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const projectId = "PVT_kwDOEjyD084BhtOr";
+            const statusFieldId = "PVTSSF_lADOEjyD084BhtOrzhgn_fY";
+            const inProgressOptionId = "e4b255ff";
+            const readyOptionId = "e910ce1a";
+            // No pisar estados que representan una etapa mas avanzada del trabajo
+            const keepOptionIds = [
+              "5c347fba", // In review
+              "85dd6979", // Done
+              "7cef383f", // Blocked
+            ];
+
+            const content = context.payload.issue || context.payload.pull_request;
+            const isAssign = context.payload.action === "assigned";
+            const remainingAssignees = (content.assignees || []).length;
+
+            // Al desasignar, solo volver a Ready si no queda nadie mas asignado
+            if (!isAssign && remainingAssignees > 0) {
+              console.log(`Still ${remainingAssignees} assignee(s), leaving status as is.`);
+              return;
+            }
+
+            // El evento de assignee puede llegar antes de que el auto-add
+            // haya metido el item al project (pasa al crear un issue ya
+            // asignado). Reintentar en vez de rendirse en el primer intento.
+            const sleep = (ms) => new Promise(r => setTimeout(r, ms));
+
+            const query = `query($id: ID!) {
+                node(id: $id) {
+                  ... on Issue {
+                    projectItems(first: 10) {
+                      nodes {
+                        id
+                        project { number }
+                        fieldValueByName(name: "Status") {
+                          ... on ProjectV2ItemFieldSingleSelectValue { name optionId }
+                        }
+                      }
+                    }
+                  }
+                  ... on PullRequest {
+                    projectItems(first: 10) {
+                      nodes {
+                        id
+                        project { number }
+                        fieldValueByName(name: "Status") {
+                          ... on ProjectV2ItemFieldSingleSelectValue { name optionId }
+                        }
+                      }
+                    }
+                  }
+                }
+              }`;
+
+            let item = null;
+
+            for (let attempt = 1; attempt <= 5; attempt++) {
+              const result = await github.graphql(query, { id: content.node_id });
+              item = result.node.projectItems.nodes.find(n => n.project.number === 3);
+              if (item) break;
+              if (attempt < 5) {
+                console.log(`Item not on project 3 yet (attempt ${attempt}/5), waiting 3s...`);
+                await sleep(3000);
+              }
+            }
+
+            if (!item) {
+              console.log("Item never showed up on project 3, skipping.");
+              return;
+            }
+
+            const current = item.fieldValueByName;
+
+            if (current && keepOptionIds.includes(current.optionId)) {
+              console.log(`Status is already "${current.name}", leaving it as is.`);
+              return;
+            }
+
+            const targetOptionId = isAssign ? inProgressOptionId : readyOptionId;
+
+            await github.graphql(
+              `mutation($project: ID!, $item: ID!, $field: ID!, $option: String!) {
+                updateProjectV2ItemFieldValue(input: {
+                  projectId: $project
+                  itemId: $item
+                  fieldId: $field
+                  value: { singleSelectOptionId: $option }
+                }) { projectV2Item { id } }
+              }`,
+              { project: projectId, item: item.id, field: statusFieldId, option: targetOptionId }
+            );
+
+            const statusName = isAssign ? "In progress" : "Ready";
+            console.log(`Status set to ${statusName} for #${content.number}`);

--- a/.github/workflows/pr-review-status.yml
+++ b/.github/workflows/pr-review-status.yml
@@ -28,8 +28,12 @@ jobs:
               : "e4b255ff"; // In progress
             const prNodeId = context.payload.pull_request.node_id;
 
-            const result = await github.graphql(
-              `query($prId: ID!) {
+            // El evento de review puede llegar antes de que el auto-add haya
+            // metido el PR al project (pasa al abrir un PR con reviewer ya
+            // cargado). Reintentar en vez de rendirse en el primer intento.
+            const sleep = (ms) => new Promise(r => setTimeout(r, ms));
+
+            const query = `query($prId: ID!) {
                 node(id: $prId) {
                   ... on PullRequest {
                     projectItems(first: 10) {
@@ -38,30 +42,70 @@ jobs:
                         project { number }
                       }
                     }
+                    closingIssuesReferences(first: 10) {
+                      nodes {
+                        number
+                        projectItems(first: 10) {
+                          nodes {
+                            id
+                            project { number }
+                          }
+                        }
+                      }
+                    }
                   }
                 }
-              }`,
-              { prId: prNodeId }
-            );
+              }`;
 
-            const item = result.node.projectItems.nodes.find(n => n.project.number === 3);
+            const itemOnProject = (items) => items.nodes.find(n => n.project.number === 3);
 
-            if (!item) {
-              console.log("PR is not on project 3 yet, skipping.");
+            // Mover el PR y tambien los issues que ese PR va a cerrar: si no,
+            // el issue se queda en In progress mientras el trabajo espera review
+            let targets = [];
+
+            for (let attempt = 1; attempt <= 5; attempt++) {
+              const result = await github.graphql(query, { prId: prNodeId });
+              const pr = result.node;
+              targets = [];
+
+              const prItem = itemOnProject(pr.projectItems);
+              if (prItem) {
+                targets.push({ id: prItem.id, label: `PR #${context.payload.pull_request.number}` });
+              }
+
+              for (const issue of pr.closingIssuesReferences.nodes) {
+                const issueItem = itemOnProject(issue.projectItems);
+                if (issueItem) {
+                  targets.push({ id: issueItem.id, label: `issue #${issue.number}` });
+                }
+              }
+
+              if (targets.length > 0) break;
+              if (attempt < 5) {
+                console.log(`Nothing on project 3 yet (attempt ${attempt}/5), waiting 3s...`);
+                await sleep(3000);
+              }
+            }
+
+            if (targets.length === 0) {
+              console.log("Neither the PR nor its linked issues showed up on project 3, skipping.");
               return;
             }
 
-            await github.graphql(
-              `mutation($project: ID!, $item: ID!, $field: ID!, $option: String!) {
-                updateProjectV2ItemFieldValue(input: {
-                  projectId: $project
-                  itemId: $item
-                  fieldId: $field
-                  value: { singleSelectOptionId: $option }
-                }) { projectV2Item { id } }
-              }`,
-              { project: projectId, item: item.id, field: statusFieldId, option: statusOptionId }
-            );
-
             const statusName = context.payload.action === "review_requested" ? "In review" : "In progress";
-            console.log(`Status set to ${statusName} for PR #${context.payload.pull_request.number}`);
+
+            for (const target of targets) {
+              await github.graphql(
+                `mutation($project: ID!, $item: ID!, $field: ID!, $option: String!) {
+                  updateProjectV2ItemFieldValue(input: {
+                    projectId: $project
+                    itemId: $item
+                    fieldId: $field
+                    value: { singleSelectOptionId: $option }
+                  }) { projectV2Item { id } }
+                }`,
+                { project: projectId, item: target.id, field: statusFieldId, option: statusOptionId }
+              );
+
+              console.log(`Status set to ${statusName} for ${target.label}`);
+            }


### PR DESCRIPTION
## Resumen
Réplica de lo ya validado end-to-end en `jar_workshops`.

### 1. Nuevo: `assignee-status.yml`
- **Se asigna alguien** → `In progress`
- **Se desasigna** → vuelve a `Ready`, solo si no queda nadie más asignado
- **Guard**: no pisa `In review`, `Done` ni `Blocked`

### 2. Fix: `pr-review-status.yml` propaga al issue vinculado
Antes solo movía el item del PR, así que el issue que ese PR cierra se quedaba en `In progress` durante toda la ventana de revisión — y el issue es lo que la gente mira en el board. Ahora mueve también los issues de `closingIssuesReferences`, en ambas direcciones.

### 3. Reintentos en ambos
El evento puede llegar antes de que el auto-add haya metido el item al board (pasa al crear un issue ya asignado, o al abrir un PR con reviewer ya cargado). Reintenta 5 veces con 3s de espera antes de rendirse.

## Validación
Probado en `jar_workshops`: assign → In progress, unassign → Ready, PR+issue → In review, sacar reviewer → ambos a In progress, guard respetado, y los reintentos verificados forzando la condición.