### PR TITLE
Usar los workflows compartidos de la org en vez de copias locales

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -5,7 +5,12 @@ name: Add to project
 on:
   issues:
     types: [opened]
-  pull_request:
+  # pull_request_target (no pull_request): los PRs que vienen de un fork no
+  # reciben los secrets del repo con pull_request, asi que el paso que
+  # genera el token de la App falla en toda contribucion externa. Es seguro
+  # aca porque este workflow nunca hace checkout del codigo del fork: solo
+  # llama a la API GraphQL de Projects.
+  pull_request_target:
     types: [opened]
 
 jobs:

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,3 +1,5 @@
+# Caller del workflow compartido en AIRclub-UdeSA/.github
+# Checklist de setup: https://github.com/AIRclub-UdeSA/.github/blob/main/CONTRIBUTING.md#setting-up-a-new-repository
 name: Add to project
 
 on:
@@ -8,18 +10,7 @@ on:
 
 jobs:
   add-to-project:
-    name: Add issue/PR to project
-    runs-on: ubuntu-latest
-    steps:
-      - name: Generar token de la GitHub App
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          owner: AIRclub-UdeSA
-
-      - uses: actions/add-to-project@v1.0.2
-        with:
-          project-url: https://github.com/orgs/AIRclub-UdeSA/projects/3
-          github-token: ${{ steps.app-token.outputs.token }}
+    uses: AIRclub-UdeSA/.github/.github/workflows/add-to-project.yml@main
+    secrets:
+      APP_ID: ${{ secrets.APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/assignee-status.yml
+++ b/.github/workflows/assignee-status.yml
@@ -1,3 +1,5 @@
+# Caller del workflow compartido en AIRclub-UdeSA/.github
+# Checklist de setup: https://github.com/AIRclub-UdeSA/.github/blob/main/CONTRIBUTING.md#setting-up-a-new-repository
 name: Sync assignee status
 
 on:
@@ -8,111 +10,7 @@ on:
 
 jobs:
   set-in-progress:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Generar token de la GitHub App
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          owner: AIRclub-UdeSA
-
-      - name: Sync project Status with assignees
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ steps.app-token.outputs.token }}
-          script: |
-            const projectId = "PVT_kwDOEjyD084BhtOr";
-            const statusFieldId = "PVTSSF_lADOEjyD084BhtOrzhgn_fY";
-            const inProgressOptionId = "e4b255ff";
-            const readyOptionId = "e910ce1a";
-            // No pisar estados que representan una etapa mas avanzada del trabajo
-            const keepOptionIds = [
-              "5c347fba", // In review
-              "85dd6979", // Done
-              "7cef383f", // Blocked
-            ];
-
-            const content = context.payload.issue || context.payload.pull_request;
-            const isAssign = context.payload.action === "assigned";
-            const remainingAssignees = (content.assignees || []).length;
-
-            // Al desasignar, solo volver a Ready si no queda nadie mas asignado
-            if (!isAssign && remainingAssignees > 0) {
-              console.log(`Still ${remainingAssignees} assignee(s), leaving status as is.`);
-              return;
-            }
-
-            // El evento de assignee puede llegar antes de que el auto-add
-            // haya metido el item al project (pasa al crear un issue ya
-            // asignado). Reintentar en vez de rendirse en el primer intento.
-            const sleep = (ms) => new Promise(r => setTimeout(r, ms));
-
-            const query = `query($id: ID!) {
-                node(id: $id) {
-                  ... on Issue {
-                    projectItems(first: 10) {
-                      nodes {
-                        id
-                        project { number }
-                        fieldValueByName(name: "Status") {
-                          ... on ProjectV2ItemFieldSingleSelectValue { name optionId }
-                        }
-                      }
-                    }
-                  }
-                  ... on PullRequest {
-                    projectItems(first: 10) {
-                      nodes {
-                        id
-                        project { number }
-                        fieldValueByName(name: "Status") {
-                          ... on ProjectV2ItemFieldSingleSelectValue { name optionId }
-                        }
-                      }
-                    }
-                  }
-                }
-              }`;
-
-            let item = null;
-
-            for (let attempt = 1; attempt <= 5; attempt++) {
-              const result = await github.graphql(query, { id: content.node_id });
-              item = result.node.projectItems.nodes.find(n => n.project.number === 3);
-              if (item) break;
-              if (attempt < 5) {
-                console.log(`Item not on project 3 yet (attempt ${attempt}/5), waiting 3s...`);
-                await sleep(3000);
-              }
-            }
-
-            if (!item) {
-              console.log("Item never showed up on project 3, skipping.");
-              return;
-            }
-
-            const current = item.fieldValueByName;
-
-            if (current && keepOptionIds.includes(current.optionId)) {
-              console.log(`Status is already "${current.name}", leaving it as is.`);
-              return;
-            }
-
-            const targetOptionId = isAssign ? inProgressOptionId : readyOptionId;
-
-            await github.graphql(
-              `mutation($project: ID!, $item: ID!, $field: ID!, $option: String!) {
-                updateProjectV2ItemFieldValue(input: {
-                  projectId: $project
-                  itemId: $item
-                  fieldId: $field
-                  value: { singleSelectOptionId: $option }
-                }) { projectV2Item { id } }
-              }`,
-              { project: projectId, item: item.id, field: statusFieldId, option: targetOptionId }
-            );
-
-            const statusName = isAssign ? "In progress" : "Ready";
-            console.log(`Status set to ${statusName} for #${content.number}`);
+    uses: AIRclub-UdeSA/.github/.github/workflows/assignee-status.yml@main
+    secrets:
+      APP_ID: ${{ secrets.APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/assignee-status.yml
+++ b/.github/workflows/assignee-status.yml
@@ -5,7 +5,12 @@ name: Sync assignee status
 on:
   issues:
     types: [assigned, unassigned]
-  pull_request:
+  # pull_request_target (no pull_request): los PRs que vienen de un fork no
+  # reciben los secrets del repo con pull_request, asi que el paso que
+  # genera el token de la App falla en toda contribucion externa. Es seguro
+  # aca porque este workflow nunca hace checkout del codigo del fork: solo
+  # llama a la API GraphQL de Projects.
+  pull_request_target:
     types: [assigned, unassigned]
 
 jobs:

--- a/.github/workflows/block-ai-coauthor.yml
+++ b/.github/workflows/block-ai-coauthor.yml
@@ -1,3 +1,5 @@
+# Caller del workflow compartido en AIRclub-UdeSA/.github
+# Checklist de setup: https://github.com/AIRclub-UdeSA/.github/blob/main/CONTRIBUTING.md#setting-up-a-new-repository
 name: Block AI co-author
 
 on:
@@ -6,22 +8,4 @@ on:
 
 jobs:
   check-commit-messages:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Reject commits co-authored by Claude/Anthropic
-        run: |
-          set -e
-          BASE="${{ github.event.pull_request.base.sha }}"
-          HEAD="${{ github.event.pull_request.head.sha }}"
-          BAD=$(git log "$BASE..$HEAD" --format="%H %B" | grep -iE "co-authored-by:.*claude|noreply@anthropic\.com" || true)
-          if [ -n "$BAD" ]; then
-            echo "Se encontraron commits con coautoria de Claude/Anthropic:"
-            echo "$BAD"
-            echo
-            echo "Sacá la línea 'Co-Authored-By: Claude ...' del mensaje del commit y volvé a pushear."
-            exit 1
-          fi
+    uses: AIRclub-UdeSA/.github/.github/workflows/block-ai-coauthor.yml@main

--- a/.github/workflows/pr-review-status.yml
+++ b/.github/workflows/pr-review-status.yml
@@ -1,3 +1,5 @@
+# Caller del workflow compartido en AIRclub-UdeSA/.github
+# Checklist de setup: https://github.com/AIRclub-UdeSA/.github/blob/main/CONTRIBUTING.md#setting-up-a-new-repository
 name: Sync PR review status
 
 on:
@@ -6,106 +8,7 @@ on:
 
 jobs:
   set-in-review:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Generar token de la GitHub App
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          owner: AIRclub-UdeSA
-
-      - name: Sync project Status with review state
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ steps.app-token.outputs.token }}
-          script: |
-            const projectId = "PVT_kwDOEjyD084BhtOr";
-            const statusFieldId = "PVTSSF_lADOEjyD084BhtOrzhgn_fY";
-            const statusOptionId = context.payload.action === "review_requested"
-              ? "5c347fba"  // In review
-              : "e4b255ff"; // In progress
-            const prNodeId = context.payload.pull_request.node_id;
-
-            // El evento de review puede llegar antes de que el auto-add haya
-            // metido el PR al project (pasa al abrir un PR con reviewer ya
-            // cargado). Reintentar en vez de rendirse en el primer intento.
-            const sleep = (ms) => new Promise(r => setTimeout(r, ms));
-
-            const query = `query($prId: ID!) {
-                node(id: $prId) {
-                  ... on PullRequest {
-                    projectItems(first: 10) {
-                      nodes {
-                        id
-                        project { number }
-                      }
-                    }
-                    closingIssuesReferences(first: 10) {
-                      nodes {
-                        number
-                        projectItems(first: 10) {
-                          nodes {
-                            id
-                            project { number }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }`;
-
-            const itemOnProject = (items) => items.nodes.find(n => n.project.number === 3);
-
-            // Mover el PR y tambien los issues que ese PR va a cerrar: si no,
-            // el issue se queda en In progress mientras el trabajo espera review
-            let targets = [];
-
-            for (let attempt = 1; attempt <= 5; attempt++) {
-              const result = await github.graphql(query, { prId: prNodeId });
-              const pr = result.node;
-              targets = [];
-
-              const prItem = itemOnProject(pr.projectItems);
-              if (prItem) {
-                targets.push({ id: prItem.id, label: `PR #${context.payload.pull_request.number}` });
-              }
-
-              for (const issue of pr.closingIssuesReferences.nodes) {
-                const issueItem = itemOnProject(issue.projectItems);
-                if (issueItem) {
-                  targets.push({ id: issueItem.id, label: `issue #${issue.number}` });
-                }
-              }
-
-              if (targets.length > 0) break;
-              if (attempt < 5) {
-                console.log(`Nothing on project 3 yet (attempt ${attempt}/5), waiting 3s...`);
-                await sleep(3000);
-              }
-            }
-
-            if (targets.length === 0) {
-              console.log("Neither the PR nor its linked issues showed up on project 3, skipping.");
-              return;
-            }
-
-            const statusName = context.payload.action === "review_requested" ? "In review" : "In progress";
-
-            for (const target of targets) {
-              await github.graphql(
-                `mutation($project: ID!, $item: ID!, $field: ID!, $option: String!) {
-                  updateProjectV2ItemFieldValue(input: {
-                    projectId: $project
-                    itemId: $item
-                    fieldId: $field
-                    value: { singleSelectOptionId: $option }
-                  }) { projectV2Item { id } }
-                }`,
-                { project: projectId, item: target.id, field: statusFieldId, option: statusOptionId }
-              );
-
-              console.log(`Status set to ${statusName} for ${target.label}`);
-            }
+    uses: AIRclub-UdeSA/.github/.github/workflows/pr-review-status.yml@main
+    secrets:
+      APP_ID: ${{ secrets.APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/pr-review-status.yml
+++ b/.github/workflows/pr-review-status.yml
@@ -3,7 +3,12 @@
 name: Sync PR review status
 
 on:
-  pull_request:
+  # pull_request_target (no pull_request): los PRs que vienen de un fork no
+  # reciben los secrets del repo con pull_request, asi que el paso que
+  # genera el token de la App falla en toda contribucion externa. Es seguro
+  # aca porque este workflow nunca hace checkout del codigo del fork: solo
+  # llama a la API GraphQL de Projects.
+  pull_request_target:
     types: [review_requested, review_request_removed]
 
 jobs:


### PR DESCRIPTION
## Resumen
Reemplaza las cuatro automatizaciones inline por callers al repo `.github` de la organización, donde la lógica ahora vive una sola vez (AIRclub-UdeSA/.github#2).

**245 líneas menos** en este repo. Los triggers siguen viviendo acá — cada repo decide *cuándo* corre; solo se comparte el *qué hace*.

## Validación
Probado end-to-end en `jar_workshops` (PR #37): las cuatro automatizaciones funcionan a través del workflow compartido — el PR se agregó solo al board, el check de co-author pasó, asignarse lo movió a In progress y pedir review lo movió a In review.