### PR TITLE
docs: add optional Docker setup guide for the simulator

### DIFF
--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -55,6 +55,7 @@ export const DOC_SECTIONS: NavSection[] = [
       { label: 'ROS 2 Humble', href: '/setup/ros2-humble/' },
       { label: 'Gazebo y RViz', href: '/setup/gazebo-rviz/' },
       { label: 'Simulador ROSMASTER', href: '/setup/simulador/' },
+      { label: 'Docker (opcional)', href: '/setup/docker/' },
     ],
   },
 ];

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -34,6 +34,8 @@ export const withBase = (path: string): string => {
 export interface NavItem {
   label: string;
   href: string;
+  /** Alternative paths off this item (e.g. an optional Docker route) shown alongside, not instead of, the linear "Siguiente" link. */
+  branches?: NavItem[];
 }
 
 export interface NavSection {
@@ -54,7 +56,11 @@ export const DOC_SECTIONS: NavSection[] = [
       { label: 'Guía de instalación', href: '/setup/' },
       { label: 'ROS 2 Humble', href: '/setup/ros2-humble/' },
       { label: 'Gazebo y RViz', href: '/setup/gazebo-rviz/' },
-      { label: 'Simulador ROSMASTER', href: '/setup/simulador/' },
+      {
+        label: 'Simulador ROSMASTER',
+        href: '/setup/simulador/',
+        branches: [{ label: 'Docker (opcional)', href: '/setup/docker/' }],
+      },
       { label: 'Docker (opcional)', href: '/setup/docker/' },
     ],
   },

--- a/src/content/docs/setup/docker.md
+++ b/src/content/docs/setup/docker.md
@@ -1,0 +1,143 @@
+---
+title: "Simulador con Docker (opcional)"
+description: "Levantá el simulador dentro de un contenedor Docker si no tenés Ubuntu 22.04 nativo."
+status: listo
+duration: "aprox. 30–60 min"
+level: intermedio
+outcome: "Al terminar, vas a tener el simulador de Donatello corriendo dentro de un contenedor, sin instalar ROS 2 Humble en tu sistema."
+---
+
+Este camino sirve si tenés Linux pero no Ubuntu 22.04 nativo — por ejemplo, una versión más nueva de Ubuntu u otra distribución. Docker aísla todo lo que necesita el simulador (ROS 2 Humble, Gazebo Fortress) en un contenedor propio, sin tocar tu instalación de base.
+
+> [!NOTE]
+> Es un camino alternativo, no el recomendado por defecto. Si tenés Ubuntu 22.04 nativo o podés instalarlo, seguí la [guía de instalación](../) normal: es más simple y es la que el club puede acompañar más de cerca. En macOS con Apple Silicon, el simulador tiene su propio camino nativo con RoboStack — mirá la sección [macOS (Apple Silicon)](https://github.com/AIRclub-UdeSA/yahboom_rosmaster#macos-apple-silicon) del repositorio.
+
+## Qué vas a dejar funcionando
+
+Docker Engine instalado, el simulador compilado dentro de un contenedor aislado, y Gazebo y RViz abriendo en tu propia pantalla para que puedas mover a Donatello desde el teclado.
+
+## Qué necesitás
+
+- Linux con Docker Engine. Probamos este recorrido en Ubuntu 24.04; cualquier distribución compatible con Docker debería funcionar igual.
+- Una cuenta con acceso a `sudo`.
+- `xauth` instalado en el sistema, para que Gazebo y RViz puedan abrir ventanas.
+- Aproximadamente 8 GB libres en disco, entre la imagen del contenedor y el workspace compilado.
+- Una GPU no es obligatoria. Si tenés una GPU NVIDIA, `container.sh` activa el NVIDIA Container Toolkit automáticamente cuando está instalado, pero no probamos ese camino nosotros — ver el aviso más abajo.
+
+## Pasos
+
+### 1. Instalar Docker Engine
+
+```bash
+sudo apt-get update
+sudo apt-get install -y ca-certificates curl
+sudo install -m 0755 -d /etc/apt/keyrings
+sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+sudo chmod a+r /etc/apt/keyrings/docker.asc
+```
+
+```bash
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+  $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+sudo apt-get update
+```
+
+```bash
+sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+```
+
+> [!NOTE]
+> Si usás otra distribución, seguí la [guía oficial de instalación](https://docs.docker.com/engine/install/) para tu caso — los pasos de arriba son para Ubuntu/Debian.
+
+### 2. Sumar tu usuario al grupo `docker`
+
+```bash
+sudo usermod -aG docker $USER
+```
+
+Este cambio no se aplica a la sesión actual. Cerrá sesión y volvé a entrar (o reiniciá) antes de continuar.
+
+```bash
+groups
+```
+
+> [!CHECK]
+> El comando anterior tiene que listar `docker` entre tus grupos. Si no aparece, todavía estás en la sesión vieja.
+
+### 3. Clonar el repositorio
+
+```bash
+mkdir -p ~/rosmaster_ws/src
+cd ~/rosmaster_ws/src
+git clone https://github.com/AIRclub-UdeSA/yahboom_rosmaster.git
+```
+
+### 4. Levantar el contenedor
+
+```bash
+cd ~/rosmaster_ws/src/yahboom_rosmaster/dockerfiles
+./container.sh start
+```
+
+La primera vez construye la imagen desde cero: descarga ROS 2 Humble, Gazebo Fortress y sus dependencias, así que puede tardar varios minutos según tu conexión. Las siguientes veces arranca en segundos.
+
+### 5. Instalar dependencias y compilar
+
+```bash
+./container.sh build
+```
+
+Este paso corre `rosdep` y `colcon build` dentro del contenedor, igual que en la instalación nativa.
+
+### 6. Abrir el simulador
+
+```bash
+./container.sh sim
+```
+
+El arranque es escalonado, igual que en la instalación nativa: primero abre Gazebo, después crea el robot y finalmente inicia sus interfaces y RViz.
+
+> [!CHECK]
+> Donatello debería aparecer en Gazebo y RViz, en ventanas sobre tu propio escritorio. Las dos aplicaciones corren dentro del contenedor, pero se muestran en tu pantalla normal.
+
+Si preferís no abrir ninguna ventana, usá la versión sin GUI:
+
+```bash
+./container.sh sim-headless
+```
+
+### 7. Moverlo desde el teclado
+
+En otra terminal, dentro de la misma carpeta `dockerfiles`:
+
+```bash
+./container.sh teleop
+```
+
+La propia herramienta imprime el mapa de teclas — es el mismo `teleop_twist_keyboard` que en la instalación nativa. Mirá la sección "Moverlo desde el teclado" de [Levantar el simulador](../simulador/#6-moverlo-desde-el-teclado) para el detalle de teclas y el modo holonómico.
+
+## Qué deberías ver
+
+Lo mismo que en la instalación nativa: el chasis se mueve y las ruedas mecanum responden en Gazebo, la pose y la odometría cambian en RViz, y podés revisar las interfaces principales con `ros2 topic list` desde otra terminal dentro del contenedor (`./container.sh enter`). La tabla completa de interfaces está en [Levantar el simulador](../simulador/#interfaces-principales).
+
+## Problemas frecuentes
+
+- **`permission denied` al correr cualquier comando `docker`**: tu sesión todavía no cargó el grupo `docker`. Cerrá sesión y volvé a entrar.
+- **Gazebo o RViz no abren ninguna ventana**: corré `./container.sh doctor` para revisar Docker, el estado del contenedor, `DISPLAY` y si `xauth` está instalado.
+- **El robot se ve con fallas o RViz repite mensajes de "jump back in time"**: quedó una corrida anterior sin cerrar del todo. Pará el contenedor completo antes de volver a lanzar `sim`:
+
+  ```bash
+  ./container.sh stop
+  ./container.sh start
+  ```
+
+- **`./container.sh sim` falla después de un `./container.sh clean`**: `clean` borra el contenedor entero, incluidas las dependencias que instaló `build`. Corré `./container.sh build` de nuevo antes de `sim`. Para simplemente pausar sin perder nada, usá `stop` en vez de `clean`.
+
+> [!WARNING]
+> No tuvimos una GPU NVIDIA disponible para validar el camino con el NVIDIA Container Toolkit. `container.sh` lo activa automáticamente si está instalado, pero probalo vos mismo antes de asumir que funciona sin ajustes.
+
+## Próximo paso
+
+Con Donatello funcionando dentro del contenedor, empezá por [01 · Talkers y listeners](../../workshops/semana-01-talkers-listeners/) para entender cómo se comunican los nodos que después van a controlarlo.

--- a/src/content/docs/setup/index.md
+++ b/src/content/docs/setup/index.md
@@ -22,3 +22,5 @@ Al terminar vas a tener ROS 2 Humble instalado, Gazebo Fortress y RViz abriendo 
 El recorrido está probado para **Ubuntu 22.04**, la plataforma oficial de ROS 2 Humble y la única que podemos acompañar directamente desde el club.
 
 Si usás WSL2, macOS o una máquina virtual, algunas partes pueden requerir ajustes adicionales. Podés probarlas, pero conviene completar primero el camino recomendado si tenés esa posibilidad.
+
+Si tenés Linux pero no Ubuntu 22.04 nativo, hay un camino alternativo con [Docker](docker/) que evita instalar ROS 2 Humble directamente en tu sistema.

--- a/src/content/docs/setup/simulador.md
+++ b/src/content/docs/setup/simulador.md
@@ -151,4 +151,6 @@ ros2 topic list
 
 ## Próximo paso
 
-Con Donatello funcionando, empezá por [01 · Talkers y listeners](../../workshops/semana-01-talkers-listeners/) para entender cómo se comunican los nodos que después van a controlarlo.
+Con Donatello funcionando, andá directo a [Sobre los workshops](../../workshops/) y empezá por [01 · Talkers y listeners](../../workshops/semana-01-talkers-listeners/) para entender cómo se comunican los nodos que después van a controlarlo.
+
+¿Preferís simular todo dentro de un container en vez de instalar ROS 2 Humble en tu sistema? Es un camino alternativo, no un paso extra: mirá la guía de [Docker (opcional)](../docker/).

--- a/src/layouts/Doc.astro
+++ b/src/layouts/Doc.astro
@@ -27,8 +27,9 @@ const weeks = allDocs
   .filter((doc) => doc.id.startsWith('workshops/semana-'))
   .sort((a, b) => a.id.localeCompare(b.id));
 
+const rawItems = DOC_SECTIONS.flatMap((section) => section.items);
 const flat = [
-  ...DOC_SECTIONS.flatMap((section) => section.items),
+  ...rawItems,
   { label: 'Sobre los workshops', href: '/workshops/' },
   ...weeks.map((week) => ({ label: week.data.title, href: `/${week.id}/` })),
 ];
@@ -40,7 +41,19 @@ const normalized = flat.map((item) => ({
 }));
 const index = normalized.findIndex((item) => item.url === currentPath);
 const prev = index > 0 ? normalized[index - 1] : undefined;
-const next = index >= 0 && index < normalized.length - 1 ? normalized[index + 1] : undefined;
+let next = index >= 0 && index < normalized.length - 1 ? normalized[index + 1] : undefined;
+
+const currentRawItem = rawItems.find((item) => withBase(item.href).replace(/\/+$/, '') === currentPath);
+const branches = (currentRawItem?.branches ?? []).map((branch) => ({
+  ...branch,
+  url: withBase(branch.href).replace(/\/+$/, '') || '/',
+}));
+const branchUrls = new Set(branches.map((branch) => branch.url));
+if (next && branchUrls.has(next.url)) {
+  // A branch (e.g. the optional Docker path) sits right after this item in DOC_SECTIONS
+  // so it doesn't hijack the linear "Siguiente" — skip past it and show it separately instead.
+  next = index + 2 < normalized.length ? normalized[index + 2] : undefined;
+}
 const currentLabel = normalized[index]?.label ?? title;
 const isSetupIndex = entry.id === 'setup' || entry.id === 'setup/index';
 const isWorkshopIndex = entry.id === 'workshops' || entry.id === 'workshops/index';
@@ -100,8 +113,8 @@ const sectionLabel = isSetup ? 'Setup' : 'Workshops';
       </article>
 
       {
-        (prev || next) && (
-          <nav class="pager" aria-label="Páginas anterior y siguiente">
+        (prev || next || branches.length > 0) && (
+          <nav class:list={['pager', { 'has-branch': branches.length > 0 }]} aria-label="Páginas anterior y siguiente">
             {prev ? (
               <a href={prev.url} rel="prev">
                 <span class="pager-label">Anterior</span>
@@ -110,6 +123,12 @@ const sectionLabel = isSetup ? 'Setup' : 'Workshops';
             ) : (
               <span />
             )}
+            {branches.map((branch) => (
+              <a class="branch" href={branch.url}>
+                <span class="pager-label">Camino alternativo</span>
+                <span class="pager-title">{branch.label}</span>
+              </a>
+            ))}
             {next && (
               <a class="next" href={next.url} rel="next">
                 <span class="pager-label">Siguiente</span>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1718,6 +1718,10 @@ footer.site-footer {
   text-align: left;
 }
 
+.docs-body .pager > a.branch {
+  text-align: left;
+}
+
 .docs-body .pager-label {
   margin-bottom: 0.3rem;
   color: var(--text-3);
@@ -1826,6 +1830,21 @@ footer.site-footer {
     padding-left: 1.5rem;
     border-left: 1px solid var(--docs-rule);
     text-align: right;
+  }
+
+  .docs-body .pager.has-branch {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .docs-body .pager.has-branch > a.branch {
+    padding-inline: 1.5rem;
+    border-left: 1px solid var(--docs-rule);
+    text-align: center;
+    align-items: center;
+  }
+
+  .docs-body .pager.has-branch > a.next {
+    padding-left: 1.5rem;
   }
 }
 


### PR DESCRIPTION
## Summary

Closes #8. Adds a fourth Setup guide, `/setup/docker/`, for Linux users without native Ubuntu 22.04 — walks through installing Docker Engine, the `container.sh` workflow (`start` → `build` → `sim`/`sim-headless` → `teleop`), and troubleshooting.

Per #8's stated dependency ("la ruta del simulador debe validarse primero en `AIRclub-UdeSA/yahboom_rosmaster`; el sitio no debe publicar comandos que todavía no hayan sido probados de punta a punta"), the commands here are exactly what was validated end-to-end in [AIRclub-UdeSA/yahboom_rosmaster#38](https://github.com/AIRclub-UdeSA/yahboom_rosmaster/pull/38) (closing yahboom_rosmaster#18), including the three container-script bugs that PR fixes — this guide only makes sense once that lands.

- New guide added to the Setup sidebar (`src/config/site.ts`) and cross-linked from the Setup index (`src/content/docs/setup/index.md`) as the alternative path — the required 3-step native path (`ros2-humble` → `gazebo-rviz` → `simulador`) is untouched.
- Frontmatter follows the existing schema (`title`, `description`, `status`, `duration`, `level`, `outcome`); content follows house style (rioplatense voseo, `[!NOTE]`/`[!CHECK]`/`[!WARNING]` callouts, real-language code fences).
- Reuses the existing "Interfaces principales" table and keyboard-teleop key map from `/setup/simulador/` via cross-links rather than duplicating them.
- Honest about scope: flags that the NVIDIA Container Toolkit path wasn't validated (no NVIDIA hardware available), and that this is Linux-only (points to the repo's own RoboStack docs for macOS).

## Test plan

- [x] `npm run check && npm run build` — 0 errors, 0 warnings, `/setup/docker/index.html` generated.
- [x] Visually verified in a local dev server: callouts render with correct `note`/`check`/`warning` classes, all cross-page anchor links resolve (`../simulador/#interfaces-principales`, `../simulador/#6-moverlo-desde-el-teclado`), Setup index's "Recorrido recomendado" 3-step list is unchanged.
- [x] Rebased on current `main`; no conflict with the unrelated upstream QoS-table update to `simulador.md`.